### PR TITLE
WIP: upgrade setup_tools to avoid Python errors

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -44,6 +44,9 @@ RUN apt-get install -y python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev
 RUN apt-get install -y cron logrotate supervisor syslog-ng-core
 RUN apt-get clean
 
+# update setuptools because otherwise you'' get python errors
+RUN pip install --upgrade setuptools
+
 WORKDIR /var/www
 RUN chown www-data:www-data /var/www
 USER www-data


### PR DESCRIPTION
Without this fix, you'll get:

```
Running python-dateutil-2.8.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-plD_ft/python-dateutil-2.8.1/egg-dist-tmp-4ws_IO
/tmp/easy_install-plD_ft/python-dateutil-2.8.1/setup.py:20: UserWarning: python_requires requires setuptools version > 24.3
  UserWarning)
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'use_scm_version'
  warnings.warn(msg)
warning: no previously-included files matching '__pycache__' found anywhere in distribution
warning: no previously-included files matching '*.py[co]' found anywhere in distribution
warning: install_lib: 'build/lib.linux-x86_64-2.7' does not exist -- no Python modules to install
```